### PR TITLE
feat: ID Bridge Resolution — Fix Bugs #1, #2, #3 (v2.4.0)

### DIFF
--- a/docs/ID-BRIDGE-v2.4.0.md
+++ b/docs/ID-BRIDGE-v2.4.0.md
@@ -1,0 +1,321 @@
+# ID Bridge Resolution — Integration Guide (v2.4.0)
+
+> **Author:** MCA (Model Context Architect)  
+> **Date:** 2026-03-07  
+> **Evidence:** MCA Smoke Test v2.3.3  
+> **Branch:** `fix/id-bridge-v2.4.0`  
+> **Module:** `src/api/id-bridge.ts`
+
+---
+
+## Problem Statement
+
+When `pa-create-flow` creates a flow via the Dataverse `workflows` entity, the POST returns a `workflowid` (primary key). This ID is a **Dataverse GUID** — the Flow Admin API (`/providers/Microsoft.ProcessSimple/...`) does NOT recognize it.
+
+The Flow Admin API uses a *different* GUID stored in the Dataverse `workflowidunique` field, which is populated **asynchronously** after creation (5–30s propagation delay, confirmed by IT).
+
+### Evidence from Smoke Test (2026-03-07)
+
+| Event | ID Returned | Works with Flow Admin? |
+|---|---|---|
+| `create-flow` (1st call) | `e45ae471-658e-4278-ac8b-5d8db6cc138b` | ❌ 404 (×6 attempts) |
+| `list-flows` (same flow) | `e45ae471-658e-4278-ac86-5b7a3ba03519` | ✅ |
+| Shared GUID prefix | `e45ae471-658e-4278-ac8` (23 chars) | — |
+| `_idMapping.dataverseWorkflowId` | `434bf8b5-b919-f111-8342-000d3a150318` | — |
+
+The `get-flow-details` call was attempted **6 consecutive times** with the Dataverse GUID. All returned `FlowNotFound` 404.
+
+---
+
+## Architecture
+
+```
+┌──────────────┐     POST /workflows     ┌──────────────────┐
+│  MCP Client  │ ──────────────────────→ │    Dataverse     │
+│ (SimTheory)  │ ← workflowid (PK)      │   workflows()    │
+└──────┬───────┘                         └───────┬──────────┘
+       │                                         │
+       │  NEW: resolveAfterCreate()              │ async propagation
+       │  polls for workflowidunique             │ (5–30 seconds)
+       │                                         ▼
+       │                                ┌──────────────────────┐
+       │  GET /flows/{resolvedId}       │  workflowidunique     │
+       │ ─────────────────────────────→ │  field populated      │
+       │                                └──────────────────────┘
+       │                                         │
+       │                                         ▼
+       │                                ┌──────────────────────┐
+       │ ← flow details + _idMapping   │  Flow Admin API      │
+       │                                │  /flows/{id}         │
+       └────────────────────────────────└──────────────────────┘
+```
+
+### Bug Coverage
+
+| Bug | Symptom | Fix Function |
+|---|---|---|
+| #1 | `create-flow` returns Dataverse GUID → 404 on follow-up calls | `resolveAfterCreate()` |
+| #2 | No wait for `workflowidunique` propagation | `resolveAfterCreate()` (polling loop) |
+| #3 | `get-flow-details` returns 404 with no fallback | `getFlowWithFallback()` |
+
+---
+
+## Integration Steps
+
+### Step 1: Import the module
+
+In `src/api/power-platform-client.ts`:
+
+```typescript
+import {
+  resolveAfterCreate,
+  getFlowWithFallback,
+  type IdBridgeDeps,
+  type CreateFlowResolution,
+} from './id-bridge.js';
+```
+
+### Step 2: Create the dependency adapter
+
+Add a private method (or getter) to your client class that builds the `IdBridgeDeps` object. This adapter bridges the existing API client methods to the interface expected by id-bridge.
+
+```typescript
+private get idBridgeDeps(): IdBridgeDeps {
+  return {
+    getWorkflowRecord: async (workflowId, select) => {
+      // Use your existing Dataverse GET method.
+      // The URL should be:
+      //   GET {dataverseUrl}/api/data/v9.2/workflows({workflowId})?$select={select}
+      try {
+        return await this.dataverseGet(`workflows(${workflowId})`, { $select: select });
+      } catch (err: any) {
+        if (err?.status === 404 || err?.message?.includes('404')) return null;
+        throw err;
+      }
+    },
+
+    getFlow: async (flowId, envId) => {
+      // Use your existing Flow Admin GET method.
+      // The URL should be:
+      //   GET .../environments/{envId}/flows/{flowId}?api-version=2016-11-01
+      try {
+        return await this.getFlowRaw(flowId, envId);
+      } catch (err: any) {
+        if (err?.status === 404 || err?.message?.includes('404')) return null;
+        throw err;
+      }
+    },
+
+    listFlows: async (envId, top = 50) => {
+      // Use your existing list-flows method.
+      const result = await this.listFlowsRaw(envId, 'all', top);
+      return result?.value ?? result ?? [];
+    },
+  };
+}
+```
+
+> **Note:** The method names (`dataverseGet`, `getFlowRaw`, `listFlowsRaw`) are
+> placeholders — adapt to your actual method names. The key contract:
+> - `getWorkflowRecord` returns `null` on 404, throws on other errors
+> - `getFlow` returns `null` on 404, throws on other errors
+> - `listFlows` returns an array of flow summary objects
+
+### Step 3: Wire into createFlow (Bug #1 + #2)
+
+Find your `createFlow` method. After the Dataverse POST succeeds and you have the Dataverse primary key:
+
+**BEFORE (current behavior — returns wrong ID):**
+```typescript
+// After Dataverse POST:
+const dataverseId = response.workflowid; // or from OData-EntityId header
+return {
+  status: 'created',
+  flowId: dataverseId,  // ← BUG: This is the Dataverse GUID, not the Flow API ID
+  displayName,
+  state: state ?? 'Stopped',
+};
+```
+
+**AFTER (correct behavior — resolved ID with metadata):**
+```typescript
+// After Dataverse POST:
+const dataverseId = response.workflowid; // or from OData-EntityId header
+
+// NEW — Wait for propagation and resolve the Flow API ID
+const resolution = await resolveAfterCreate(
+  dataverseId,
+  envId,
+  this.idBridgeDeps,
+  displayName,  // enables list-flows fallback
+);
+
+return {
+  status: 'created',
+  flowId: resolution.flowId,             // ← FIXED: Flow API ID
+  displayName,
+  state: state ?? 'Stopped',
+  _idMapping: resolution._idMapping,     // ← NEW: Resolution metadata
+  _propagation: resolution._propagation, // ← NEW: Propagation timing
+};
+```
+
+### Step 4: Wire into getFlowDetails (Bug #3)
+
+Find your `getFlowDetails` method.
+
+**BEFORE (current — no fallback on 404):**
+```typescript
+async getFlowDetails(flowId: string, envId: string) {
+  const url = `.../${envId}/flows/${flowId}?api-version=2016-11-01`;
+  const resp = await this.authenticatedFetch(url);
+  if (resp.status === 404) {
+    throw new Error(`API Error 404: Could not find flow '${flowId}'.`);
+  }
+  return resp.json();
+}
+```
+
+**AFTER (with fallback cascade):**
+```typescript
+async getFlowDetails(flowId: string, envId: string) {
+  const result = await getFlowWithFallback(flowId, envId, this.idBridgeDeps);
+  return {
+    ...result.data,
+    _idMapping: result._idMapping,  // include resolution metadata
+  };
+}
+```
+
+### Step 5: Bump version
+
+In `package.json`:
+```json
+"version": "2.4.0"
+```
+
+---
+
+## Configuration
+
+The default propagation config is:
+
+```typescript
+{
+  maxAttempts: 6,      // 6 poll iterations
+  baseDelayMs: 3_000,  // 3s initial delay
+  backoff: 1.5,        // 1.5× multiplier
+  maxDelayMs: 15_000,  // 15s max per poll
+}
+```
+
+**Resulting poll schedule:**
+| Attempt | Delay | Cumulative |
+|---|---|---|
+| 1 | 3.0s | 3.0s |
+| 2 | 4.5s | 7.5s |
+| 3 | 6.75s | 14.25s |
+| 4 | 10.1s | 24.35s |
+| 5 | 15.0s (capped) | 39.35s |
+| 6 | 15.0s (capped) | 54.35s |
+
+**Worst case:** ~54 seconds if Dataverse never resolves, then falls back to list-flows.
+This covers the observed 5–30 second propagation window with margin.
+
+To override, pass a partial config:
+```typescript
+const resolution = await resolveAfterCreate(
+  dataverseId, envId, this.idBridgeDeps, displayName,
+  { maxAttempts: 8, baseDelayMs: 2000 },  // custom config
+);
+```
+
+---
+
+## Testing
+
+### Smoke Test Sequence
+
+1. **Create a test flow:**
+   ```
+   pa-create-flow "ID Bridge Test v2.4.0" { definition... } Stopped
+   ```
+   **Expected response fields:**
+   - `flowId`: A Flow API ID (NOT the Dataverse GUID)
+   - `_idMapping.resolvedVia`: `"workflowidunique"`
+   - `_propagation.verified`: `true`
+   - `_propagation.delayMs`: Typically 3000–15000
+   - `_propagation.attempts`: Typically 1–3
+
+2. **Get flow details with the returned ID:**
+   ```
+   pa-get-flow-details {flowId from step 1}
+   ```
+   **Expected:** Returns full flow details (NOT a 404)
+
+3. **Get flow details with a Dataverse GUID (regression test):**
+   ```
+   pa-get-flow-details {_idMapping.dataverseWorkflowId from step 1}
+   ```
+   **Expected:** Resolves via fallback, returns flow details with
+   `_idMapping.resolvedVia: "workflowidunique"`
+
+4. **Clean up:**
+   ```
+   pa-delete-flow {flowId from step 1}
+   ```
+
+### Expected Logs — Success Path (Bug #1 + #2)
+
+```
+[IdBridge] Resolving Flow API ID for Dataverse ID: {dvId}
+[IdBridge] Propagation poll 1/6 — waiting 3000ms
+[IdBridge] Candidate: {flowApiId} (via workflowidunique). Verifying on Flow Admin API...
+[IdBridge] ✓ Propagation verified in 3200ms (1 attempts, workflowidunique)
+```
+
+### Expected Logs — Fallback Path (Bug #3)
+
+```
+[IdBridge] Direct lookup: {dvGuid}
+[IdBridge] 404 on direct lookup for {dvGuid}. Starting fallback resolution...
+[IdBridge] Attempting Dataverse resolution for {dvGuid}...
+[IdBridge] Dataverse resolved: {dvGuid} → {flowApiId} (via workflowidunique)
+```
+
+### Expected Logs — Worst Case (Degraded)
+
+```
+[IdBridge] Resolving Flow API ID for Dataverse ID: {dvId}
+[IdBridge] Propagation poll 1/6 — waiting 3000ms
+[IdBridge] Poll 1: workflowidunique not yet populated
+[IdBridge] Propagation poll 2/6 — waiting 4500ms
+...
+[IdBridge] Propagation poll 6/6 — waiting 15000ms
+[IdBridge] Dataverse poll exhausted after 6 attempts. Searching list-flows for "..."
+[IdBridge] ✓ Resolved via list-flows search: {flowApiId} (42000ms)
+```
+
+---
+
+## Rollback
+
+If issues occur after deployment:
+
+1. **Revert the import** and `resolveAfterCreate` / `getFlowWithFallback` calls in `power-platform-client.ts`
+2. **`id-bridge.ts` can remain** in the codebase — it has zero side effects and no global state
+3. Redeploy
+
+The module is pure functions with dependency injection. It touches nothing unless explicitly called.
+
+---
+
+## Future Improvements (v2.5.0+)
+
+| # | Improvement | Description |
+|---|---|---|
+| 4 | Cache EnvResolver | `[EnvResolver]` re-runs on every request — should cache at startup |
+| 5 | Structured error logs | Error bodies logged line-by-line; should be single structured entry |
+| 6 | Suppress npm startup noise | Empty log lines from `npm run start` |
+| 7 | Request correlation IDs | No way to trace concurrent requests through logs |
+| 8 | Idempotency detection logging | No log distinguishing "created new" vs "returning existing" |

--- a/src/api/id-bridge.ts
+++ b/src/api/id-bridge.ts
@@ -1,0 +1,426 @@
+// ════════════════════════════════════════════════════════════════
+// ID Bridge Resolution — Power Automate MCP v2.4.0
+// ════════════════════════════════════════════════════════════════
+//
+// Resolves Dataverse workflow GUIDs → Flow Admin API IDs.
+//
+// Fixes:
+//   Bug #1: create-flow returns Dataverse PK instead of Flow API ID
+//   Bug #2: No post-creation propagation wait
+//   Bug #3: get-flow-details has no 404 → resolution fallback
+//
+// Usage: Import and wire into power-platform-client.ts
+//   See docs/ID-BRIDGE-v2.4.0.md for integration steps.
+//
+// Evidence: MCA Smoke Test v2.3.3 (2026-03-07)
+//   create-flow returned: e45ae471-658e-4278-ac8b-5d8db6cc138b  (Dataverse GUID → 404)
+//   list-flows showed:    e45ae471-658e-4278-ac86-5b7a3ba03519  (Flow API ID → works)
+//   6 consecutive 404s on get-flow-details with the Dataverse GUID.
+// ════════════════════════════════════════════════════════════════
+
+// ─── Types ──────────────────────────────────────────────────────
+
+export interface IdBridgeConfig {
+  /** Max propagation poll iterations (default: 6) */
+  maxAttempts: number;
+  /** Initial delay between polls in ms (default: 3000) */
+  baseDelayMs: number;
+  /** Delay multiplier per attempt (default: 1.5) */
+  backoff: number;
+  /** Maximum delay cap per attempt in ms (default: 15000) */
+  maxDelayMs: number;
+}
+
+export interface IdMapping {
+  /** The resolved Flow Admin API ID (usable with /flows/{id}) */
+  flowApiId: string;
+  /** The Dataverse workflow primary key */
+  dataverseWorkflowId: string;
+  /** How the ID was resolved */
+  resolvedVia: 'workflowidunique' | 'name' | 'list-flows' | 'direct';
+}
+
+export interface PropagationMeta {
+  /** Whether the resolved ID was verified on the Flow Admin API */
+  verified: boolean;
+  /** Total elapsed time for resolution in ms */
+  delayMs: number;
+  /** Number of poll/resolution attempts made */
+  attempts: number;
+}
+
+export interface CreateFlowResolution {
+  /** The correct Flow API ID to return to callers */
+  flowId: string;
+  /** Mapping metadata showing Dataverse → Flow API translation */
+  _idMapping: IdMapping;
+  /** Propagation wait metadata */
+  _propagation: PropagationMeta;
+}
+
+/**
+ * Dependency contract — injected from the existing API client.
+ * This keeps id-bridge.ts decoupled from auth, HTTP clients, and URL construction.
+ */
+export interface IdBridgeDeps {
+  /**
+   * Query a single Dataverse workflow record by its primary key.
+   * Should call: GET {dataverseUrl}/api/data/v9.2/workflows({workflowId})?$select={select}
+   * @returns The record object, or null if not found.
+   */
+  getWorkflowRecord(
+    workflowId: string,
+    select: string,
+  ): Promise<Record<string, any> | null>;
+
+  /**
+   * GET a single flow from the Flow Admin API.
+   * Should call: GET .../environments/{envId}/flows/{flowId}?api-version=2016-11-01
+   * @returns The flow object, or null on 404. Should throw on non-404 errors.
+   */
+  getFlow(
+    flowId: string,
+    envId: string,
+  ): Promise<Record<string, any> | null>;
+
+  /**
+   * List flows from the Flow Admin API.
+   * Should call: GET .../environments/{envId}/v2/flows?$filter=all&$top={top}
+   * @returns Array of flow summary objects.
+   */
+  listFlows(envId: string, top?: number): Promise<Array<Record<string, any>>>;
+}
+
+// ─── Defaults ───────────────────────────────────────────────────
+
+const DEFAULTS: IdBridgeConfig = {
+  maxAttempts: 6,
+  baseDelayMs: 3_000,
+  backoff: 1.5,
+  maxDelayMs: 15_000,
+};
+
+// ─── Internal helpers ───────────────────────────────────────────
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+function log(level: 'info' | 'warn' | 'error', msg: string): void {
+  const fn =
+    level === 'error'
+      ? console.error
+      : level === 'warn'
+        ? console.warn
+        : console.log;
+  fn(`[IdBridge] ${msg}`);
+}
+
+function is404(err: unknown): boolean {
+  if (err == null || typeof err !== 'object') return false;
+  const e = err as Record<string, any>;
+  return (
+    e.status === 404 ||
+    e.statusCode === 404 ||
+    e.response?.status === 404 ||
+    String(e.message ?? '').includes('404') ||
+    String(e.message ?? '').includes('FlowNotFound')
+  );
+}
+
+function buildResult(
+  flowApiId: string,
+  dvId: string,
+  via: IdMapping['resolvedVia'],
+  delayMs: number,
+  attempts: number,
+  verified: boolean,
+): CreateFlowResolution {
+  return {
+    flowId: flowApiId,
+    _idMapping: { flowApiId, dataverseWorkflowId: dvId, resolvedVia: via },
+    _propagation: { verified, delayMs, attempts },
+  };
+}
+
+// ════════════════════════════════════════════════════════════════
+// Bug #1 + #2: Post-Creation ID Resolution with Propagation Wait
+// ════════════════════════════════════════════════════════════════
+//
+// After a Dataverse POST creates a workflow, the Flow Admin API
+// doesn't immediately recognize the new flow. The correct Flow
+// API ID lives in the `workflowidunique` field, which is populated
+// asynchronously (5-30s observed, confirmed by IT).
+//
+// This function polls Dataverse until the field is populated,
+// then verifies the ID works on the Flow Admin API.
+// ════════════════════════════════════════════════════════════════
+
+/**
+ * Resolve the correct Flow API ID after a Dataverse workflow creation.
+ *
+ * Strategy chain:
+ *   1. Poll Dataverse for `workflowidunique` (primary strategy)
+ *   2. Search `list-flows` by display name (fallback)
+ *   3. Return unverified Dataverse ID with warning (degraded)
+ *
+ * @param dataverseId  - The ID returned from the Dataverse POST (workflowid PK or similar)
+ * @param envId        - Power Platform environment ID
+ * @param deps         - Injected API dependencies
+ * @param displayName  - Flow display name (enables list-flows fallback)
+ * @param config       - Optional config overrides
+ */
+export async function resolveAfterCreate(
+  dataverseId: string,
+  envId: string,
+  deps: IdBridgeDeps,
+  displayName?: string,
+  config: Partial<IdBridgeConfig> = {},
+): Promise<CreateFlowResolution> {
+  const cfg = { ...DEFAULTS, ...config };
+  const t0 = Date.now();
+  let attempts = 0;
+
+  log('info', `Resolving Flow API ID for Dataverse ID: ${dataverseId}`);
+
+  // ── Strategy 1: Poll Dataverse for workflowidunique ────────────
+  for (let i = 1; i <= cfg.maxAttempts; i++) {
+    attempts = i;
+    const delay = Math.min(
+      Math.round(cfg.baseDelayMs * Math.pow(cfg.backoff, i - 1)),
+      cfg.maxDelayMs,
+    );
+
+    log('info', `Propagation poll ${i}/${cfg.maxAttempts} — waiting ${delay}ms`);
+    await sleep(delay);
+
+    try {
+      const rec = await deps.getWorkflowRecord(
+        dataverseId,
+        'workflowidunique,name,statecode',
+      );
+
+      if (!rec) {
+        log('warn', `Poll ${i}: Dataverse record not found yet`);
+        continue;
+      }
+
+      // Extract the candidate Flow API ID
+      const candidate = rec.workflowidunique ?? rec.name;
+
+      if (!candidate) {
+        log('warn', `Poll ${i}: workflowidunique not yet populated`);
+        continue;
+      }
+
+      // Don't accept the candidate if it's the same as the input
+      // (means the field hasn't resolved to the Flow API ID yet)
+      if (candidate === dataverseId) {
+        log('warn', `Poll ${i}: workflowidunique matches input — not yet resolved`);
+        continue;
+      }
+
+      const via: IdMapping['resolvedVia'] = rec.workflowidunique
+        ? 'workflowidunique'
+        : 'name';
+
+      log('info', `Candidate: ${candidate} (via ${via}). Verifying on Flow Admin API...`);
+
+      // Verify the candidate is visible on the Flow Admin API
+      try {
+        const flow = await deps.getFlow(candidate, envId);
+        if (flow) {
+          const elapsed = Date.now() - t0;
+          log(
+            'info',
+            `✓ Propagation verified in ${elapsed}ms (${attempts} attempts, ${via})`,
+          );
+          return buildResult(candidate, dataverseId, via, elapsed, attempts, true);
+        }
+        log('warn', `Candidate ${candidate} not yet visible on Flow Admin API`);
+      } catch (flowErr) {
+        if (!is404(flowErr)) throw flowErr; // non-404 = real error, don't swallow
+        log('warn', `Candidate ${candidate}: Flow Admin API returned 404 — not propagated yet`);
+      }
+    } catch (dvErr) {
+      log('warn', `Poll ${i} Dataverse query failed: ${(dvErr as Error).message}`);
+    }
+  }
+
+  // ── Strategy 2: Search list-flows by display name ──────────────
+  if (displayName) {
+    log(
+      'warn',
+      `Dataverse poll exhausted after ${attempts} attempts. ` +
+        `Searching list-flows for "${displayName}"...`,
+    );
+
+    try {
+      const flows = await deps.listFlows(envId, 100);
+      const match = flows.find((f) => {
+        const name =
+          f.properties?.displayName ?? f.displayName ?? f.properties?.definition?.metadata?.name;
+        return name === displayName;
+      });
+
+      if (match) {
+        const fid: string = match.name ?? match.id;
+        const elapsed = Date.now() - t0;
+        log('info', `✓ Resolved via list-flows search: ${fid} (${elapsed}ms)`);
+        return buildResult(fid, dataverseId, 'list-flows', elapsed, attempts + 1, true);
+      }
+
+      log('warn', `Flow "${displayName}" not found in list-flows (${flows.length} flows scanned)`);
+    } catch (err) {
+      log('error', `List-flows fallback failed: ${(err as Error).message}`);
+    }
+  }
+
+  // ── Strategy 3: Degraded — return Dataverse ID with warning ────
+  const elapsed = Date.now() - t0;
+  log(
+    'error',
+    `✗ Resolution FAILED after ${elapsed}ms (${attempts} attempts). ` +
+      `Returning unverified Dataverse ID. Caller may get 404s.`,
+  );
+  return buildResult(dataverseId, dataverseId, 'direct', elapsed, attempts, false);
+}
+
+// ════════════════════════════════════════════════════════════════
+// Bug #3: get-flow-details with 404 → ID Resolution Fallback
+// ════════════════════════════════════════════════════════════════
+//
+// When get-flow-details receives a 404, the provided ID may be a
+// Dataverse GUID. This function cascades through resolution
+// strategies to find the correct Flow API ID.
+// ════════════════════════════════════════════════════════════════
+
+/**
+ * Get flow details with automatic 404 → ID resolution fallback.
+ *
+ * Strategy chain on 404:
+ *   1. Direct lookup (provided ID as-is)
+ *   2. Treat ID as Dataverse PK → query for workflowidunique → retry
+ *   3. Partial GUID prefix match on list-flows → retry
+ *
+ * @param flowId - The flow ID (may be a Flow API ID or Dataverse GUID)
+ * @param envId  - Power Platform environment ID
+ * @param deps   - Injected API dependencies
+ */
+export async function getFlowWithFallback(
+  flowId: string,
+  envId: string,
+  deps: IdBridgeDeps,
+): Promise<{ data: Record<string, any>; _idMapping: IdMapping }> {
+  // ── Attempt 1: Direct lookup ──────────────────────────────────
+  log('info', `Direct lookup: ${flowId}`);
+  try {
+    const flow = await deps.getFlow(flowId, envId);
+    if (flow) {
+      return {
+        data: flow,
+        _idMapping: {
+          flowApiId: flowId,
+          dataverseWorkflowId: flowId,
+          resolvedVia: 'direct',
+        },
+      };
+    }
+  } catch (err: unknown) {
+    if (!is404(err)) throw err; // non-404 = real error
+    log('warn', `404 on direct lookup for ${flowId}. Starting fallback resolution...`);
+  }
+
+  // ── Attempt 2: Dataverse GUID → workflowidunique resolution ───
+  try {
+    log('info', `Attempting Dataverse resolution for ${flowId}...`);
+    const rec = await deps.getWorkflowRecord(flowId, 'workflowidunique,name');
+
+    if (rec) {
+      const resolved = rec.workflowidunique ?? rec.name;
+
+      if (resolved && resolved !== flowId) {
+        const via: IdMapping['resolvedVia'] = rec.workflowidunique
+          ? 'workflowidunique'
+          : 'name';
+        log('info', `Dataverse resolved: ${flowId} → ${resolved} (via ${via})`);
+
+        try {
+          const flow = await deps.getFlow(resolved, envId);
+          if (flow) {
+            return {
+              data: flow,
+              _idMapping: {
+                flowApiId: resolved,
+                dataverseWorkflowId: flowId,
+                resolvedVia: via,
+              },
+            };
+          }
+        } catch (flowErr) {
+          if (!is404(flowErr)) throw flowErr;
+          log('warn', `Resolved ID ${resolved} also returned 404`);
+        }
+      } else {
+        log('warn', `Dataverse record found but no distinct workflowidunique`);
+      }
+    } else {
+      log('warn', `No Dataverse record found for ${flowId}`);
+    }
+  } catch (dvErr) {
+    log('warn', `Dataverse resolution failed: ${(dvErr as Error).message}`);
+  }
+
+  // ── Attempt 3: Partial GUID prefix match on list-flows ────────
+  //
+  // Evidence from smoke test: Dataverse GUID and Flow API ID share
+  // the first 23 characters, then diverge:
+  //   DV:   e45ae471-658e-4278-ac8b-5d8db6cc138b
+  //   Flow: e45ae471-658e-4278-ac86-5b7a3ba03519
+  //   Match: e45ae471-658e-4278-ac8  (23 chars)
+  //
+  // We use this as a fuzzy-match heuristic as a last resort.
+  log('warn', `Trying partial GUID prefix match on list-flows...`);
+  try {
+    // Use first 23 chars as the shared prefix (covers groups 1-3 + start of group 4)
+    const prefix = flowId.substring(0, 23);
+    const flows = await deps.listFlows(envId, 100);
+
+    const match = flows.find((f) => {
+      const fid: string = f.name ?? f.id ?? '';
+      return fid.startsWith(prefix) && fid !== flowId;
+    });
+
+    if (match) {
+      const resolved: string = match.name ?? match.id;
+      log('info', `Partial GUID match found: ${resolved}`);
+
+      try {
+        const flow = await deps.getFlow(resolved, envId);
+        if (flow) {
+          return {
+            data: flow,
+            _idMapping: {
+              flowApiId: resolved,
+              dataverseWorkflowId: flowId,
+              resolvedVia: 'list-flows',
+            },
+          };
+        }
+      } catch (flowErr) {
+        if (!is404(flowErr)) throw flowErr;
+        log('error', `Partial GUID match ${resolved} also returned 404`);
+      }
+    } else {
+      log('warn', `No partial GUID match found (scanned ${flows.length} flows, prefix: ${prefix})`);
+    }
+  } catch (err) {
+    log('error', `List-flows search failed: ${(err as Error).message}`);
+  }
+
+  // ── All strategies exhausted ──────────────────────────────────
+  const errorMsg =
+    `FlowNotFound: Could not resolve '${flowId}' via any strategy ` +
+    `(direct → 404, Dataverse → no match, list-flows → no match). ` +
+    `The ID may be a Dataverse GUID that hasn't propagated, or the flow may not exist.`;
+  log('error', errorMsg);
+  throw new Error(errorMsg);
+}


### PR DESCRIPTION
# ID Bridge Resolution — v2.4.0\n\n## Summary\n\nFixes three critical, interdependent bugs causing `FlowNotFound` 404 errors after flow creation.\n\n### Evidence: MCA Smoke Test v2.3.3 (2026-03-07)\n- `create-flow` returned Dataverse GUID `...ac8b-5d8db6cc138b` → **6 consecutive 404s**\n- `list-flows` showed correct Flow API ID `...ac86-5b7a3ba03519` → **works**\n- GUIDs share first 23 characters, then diverge\n\n---\n\n## Bugs Fixed\n\n| Bug | Severity | Description |\n|---|---|---|\n| **#1** | 🔴 CRITICAL | `create-flow` returns Dataverse `workflowid` PK instead of the Flow Admin API ID (`workflowidunique`) |\n| **#2** | 🔴 CRITICAL | No post-creation propagation wait — `workflowidunique` field is populated async (5–30s) |\n| **#3** | 🔴 CRITICAL | `get-flow-details` returns 404 immediately with no fallback resolution attempt |\n\n## What's Added\n\n### New Module: `src/api/id-bridge.ts`\n\nSelf-contained, zero-side-effect module with dependency injection:\n\n- **`resolveAfterCreate()`** — Post-creation propagation poll\n  - Polls Dataverse for `workflowidunique` with exponential backoff (3s → 15s cap, 6 attempts)\n  - Verifies resolved ID is visible on Flow Admin API before returning\n  - Falls back to `list-flows` display name search if Dataverse poll exhausts\n  - Returns `_idMapping` and `_propagation` metadata\n\n- **`getFlowWithFallback()`** — 404 → resolution cascade\n  - Attempt 1: Direct lookup (as-is)\n  - Attempt 2: Treat ID as Dataverse GUID → query `workflowidunique` → retry\n  - Attempt 3: Partial GUID prefix match (23 chars) on `list-flows` → retry\n  - Returns `_idMapping` metadata showing resolution path\n\n### Integration Guide: `docs/ID-BRIDGE-v2.4.0.md`\n\nStep-by-step wiring instructions into `power-platform-client.ts`:\n1. Import the module\n2. Create the `IdBridgeDeps` adapter\n3. Wire into `createFlow` (Bugs #1 + #2)\n4. Wire into `getFlowDetails` (Bug #3)\n5. Bump version to 2.4.0\n\nIncludes smoke test verification sequence, expected log patterns, rollback plan, and configuration reference.\n\n## Integration Required\n\n⚠️ **This PR adds the module and docs. The wiring into `power-platform-client.ts` must be done manually** because the GitHub API cannot fetch the 23KB source file for automated editing.\n\nSee `docs/ID-BRIDGE-v2.4.0.md` → \"Integration Steps\" for the exact code changes.\n\n## Testing Checklist\n\n- [ ] Create a test flow → verify `flowId` is Flow API ID (not Dataverse GUID)\n- [ ] Verify `_idMapping.resolvedVia` is `\"workflowidunique\"`\n- [ ] Verify `_propagation.verified` is `true`\n- [ ] Call `get-flow-details` with returned ID → success\n- [ ] Call `get-flow-details` with Dataverse GUID → fallback resolution success\n- [ ] Delete test flow\n\n## Future (Not in Scope)\n\n| # | Issue | Target |\n|---|---|---|\n| 4 | EnvResolver runs on every request | v2.5.0 |\n| 5 | Error bodies logged line-by-line | v2.5.0 |\n| 6 | Empty npm startup log lines | v2.5.0 |\n| 7 | No request correlation IDs | v2.5.0 |