### PR TITLE
fix(v2.4.0): SSE reconnect crash guard + version bump + banner cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "power-automate-mcp",
-  "version": "2.3.3",
+  "version": "2.4.0",
   "description": "Model Context Protocol server for Microsoft Power Automate — Simtheory.ai native",
   "author": "GROW by Bolthouse Fresh (Architected by MCA)",
   "license": "UNLICENSED",

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import { ToolResult, ToolDefinition } from './types.js';
 // Configuration
 // =============================================================================
 const PORT = parseInt(process.env.PORT || '8080', 10);
-const VERSION = '2.3.3';
+const VERSION = '2.4.0';
 
 // =============================================================================
 // Core Services
@@ -445,6 +445,19 @@ const sseTransports = new Map<string, SSEServerTransport>();
 
 app.get('/sse', async (req: Request, res: Response) => {
   console.log('[SSE] Connection initiated');
+  
+  // ── SSE Reconnect Guard ──────────────────────────────────────
+  // Simtheory.ai may reconnect (keepalive, network blip, session
+  // refresh). The MCP SDK enforces one transport per Protocol
+  // instance. Without this guard, a reconnect crashes the process
+  // with "Already connected to a transport" (protocol.js:217).
+  try {
+    await mcpServer.close();
+    console.log('[SSE] Previous transport closed (reconnect detected)');
+  } catch (_) {
+    // No existing connection — first connect. That's fine.
+  }
+
   const transport = new SSEServerTransport('/messages', res);
   sseTransports.set(transport.sessionId, transport);
   res.on('close', () => {
@@ -556,9 +569,9 @@ app.listen(PORT, () => {
   console.log(`[Init] SSE:    http://localhost:${PORT}/sse`);
   console.log(`[Init] REST:   http://localhost:${PORT}/mcp (+ /, /api, /tools)`);
   console.log(`[Init] Health: http://localhost:${PORT}/health`);
-  console.log(`[Init] API:    BAP admin + Flow admin + PowerApps admin + Dataverse dynamic (4 scopes)`);
-  console.log(`[Init] Write:  Dataverse Web API (create + update flows)`);
-  console.log(`[Init] ID:     workflowidunique bridge (Dataverse -> Flow API)`);
-  console.log(`[Init] Tools:  ${toolDefs.length} (including Dataverse-backed create + update)`);
+  console.log(`[Init] API:    BAP admin + Flow admin + PowerApps admin (3 scopes)`);
+  console.log(`[Init] Write:  Flow Management API (create + update flows)`);
+  console.log(`[Init] ID:     Direct Flow API (no bridge needed)`);
+  console.log(`[Init] Tools:  ${toolDefs.length} (including Flow API-backed create + update)`);
   console.log('');
 });


### PR DESCRIPTION
## Summary

Addresses the critical SSE crash (`"Already connected to a transport"` at `protocol.js:217`) that occurs when Simtheory.ai reconnects to the MCP server.

## Changes

### 🛡️ SSE Reconnect Guard (`src/index.ts`)
- Calls `mcpServer.close()` before each new `mcpServer.connect(transport)` in the `/sse` handler
- Gracefully handles first-connect (no prior transport) via try/catch
- Prevents Railway container crash on reconnect (keepalive, network blip, session refresh)

### Why this matters
The MCP operates as a **privileged automation proxy** — every API call executes under the service principal's full admin rights, not individual user permissions. An SSE crash during a flow creation leaves half-built flows with admin-level permissions in limbo.

### 📦 Version Bump
- `src/index.ts` VERSION: `2.3.3` → `2.4.0`
- `package.json` version: `2.3.3` → `2.4.0`

### 🏷️ Banner Cleanup
Updated startup banner to reflect current architecture:
- `BAP admin + Flow admin + PowerApps admin (3 scopes)` (was 4 + Dataverse)
- `Flow Management API` (was Dataverse Web API)
- `Direct Flow API` (was workflowidunique bridge)
- `Flow API-backed create + update` (was Dataverse-backed)

## Testing
- Railway redeploy will validate health endpoint reports v2.4.0
- Simtheory.ai SSE reconnect should no longer crash the process

---
*Architected by MCA for GROW by Bolthouse Fresh*