### PR TITLE
feat(v3.1.0): wire pa-get-connection and pa-delete-connection tools

### DIFF
--- a/src/api/power-platform-client.ts
+++ b/src/api/power-platform-client.ts
@@ -1,6 +1,8 @@
 /**
  * PowerPlatformClient — HTTP client for Power Platform APIs
  *
+ * v3.1.0: Added getConnectionDetails() and deleteConnection() methods
+ *
  * v3.0.3: Dual-path GET for getFlowDetails with metadata fields:
  *   _fetchedVia, _definitionStatus, _definitionNote
  *
@@ -9,7 +11,7 @@
  *   - Delegated user (UserAuthManager) for write operations + user-scoped reads
  *   - getFlowDetails: tries delegated first, falls back to admin
  *
- * @version 3.0.3
+ * @version 3.1.0
  */
 
 import axios from 'axios';
@@ -458,5 +460,26 @@ export class PowerPlatformClient {
   async listConnections(envId: string): Promise<any> {
     const path = `/scopes/admin/environments/${envId}/connections`;
     return this.adminFlowRequest(path);
+  }
+
+  /**
+   * Gets details of a specific connection.
+   * v3.1.0: New method — wired to pa-get-connection tool.
+   */
+  async getConnectionDetails(envId: string, connectionName: string): Promise<any> {
+    const path = `/scopes/admin/environments/${envId}/connections/${connectionName}`;
+    return this.adminFlowRequest(path);
+  }
+
+  /**
+   * Deletes a connection permanently.
+   * v3.1.0: New method — wired to pa-delete-connection tool.
+   *
+   * WARNING: Deleting a connection may break flows that depend on it.
+   */
+  async deleteConnection(envId: string, connectionName: string): Promise<void> {
+    const path = `/scopes/admin/environments/${envId}/connections/${connectionName}`;
+    await this.adminFlowRequest(path, 'DELETE');
+    console.log(`[deleteConnection] Connection ${connectionName} deleted`);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ import { registerAuthTools } from './tools/auth-tool-handlers.js';
 // Configuration
 // =============================================================================
 const PORT = parseInt(process.env.PORT || '8080', 10);
-const VERSION = '3.0.3';
+const VERSION = '3.1.0';
 
 // =============================================================================
 // Core Services
@@ -53,6 +53,7 @@ function fail(msg: string): ToolResult {
 // =============================================================================
 // Tool Definitions (shared between SSE + REST transports)
 //
+// v3.1.0: Added pa-get-connection and pa-delete-connection tools.
 // v3.0.3: All descriptions sourced from TOOL_DESCRIPTIONS which include
 // mandatory flow creation procedure guidance for AI agents.
 // =============================================================================
@@ -346,6 +347,61 @@ const toolDefs: ToolDefinition[] = [
       } catch (e: any) { return fail(e.message); }
     },
   },
+  // ---- Get Connection Details ----
+  {
+    name: 'pa-get-connection',
+    description: TOOL_DESCRIPTIONS['pa-get-connection'],
+    inputSchema: {
+      type: 'object',
+      properties: {
+        connectionId: { type: 'string', description: 'Connection ID (name field from pa-list-connections).' },
+        environmentId: { type: 'string', description: 'Power Platform environment ID.' },
+      },
+      required: ['connectionId'],
+    },
+    handler: async (p: any) => {
+      try {
+        const envId = resolveEnvironmentId(p.environmentId);
+        const result = await client.getConnectionDetails(envId, p.connectionId);
+        const c = result;
+        return ok({
+          connectionId: c.name,
+          displayName: c.properties?.displayName,
+          apiId: c.properties?.apiId,
+          connectorDisplayName: c.properties?.apiId?.split('/').pop(),
+          status: c.properties?.statuses?.[0]?.status,
+          createdTime: c.properties?.createdTime,
+          createdBy: c.properties?.createdBy,
+          statuses: c.properties?.statuses,
+          connectionParameters: c.properties?.connectionParametersSet || null,
+        });
+      } catch (e: any) { return fail(e.message); }
+    },
+  },
+  // ---- Delete Connection ----
+  {
+    name: 'pa-delete-connection',
+    description: TOOL_DESCRIPTIONS['pa-delete-connection'],
+    inputSchema: {
+      type: 'object',
+      properties: {
+        connectionId: { type: 'string', description: 'Connection ID (name field) to delete.' },
+        environmentId: { type: 'string', description: 'Power Platform environment ID.' },
+      },
+      required: ['connectionId'],
+    },
+    handler: async (p: any) => {
+      try {
+        const envId = resolveEnvironmentId(p.environmentId);
+        await client.deleteConnection(envId, p.connectionId);
+        return ok({
+          status: 'deleted',
+          connectionId: p.connectionId,
+          message: `Connection ${p.connectionId} has been permanently deleted.`,
+        });
+      } catch (e: any) { return fail(e.message); }
+    },
+  },
   // =========================================================================
   // AUTH TOOLS (Device Code Flow)
   // Methods: startAuth(), pollAuth(), getAuthStatus()
@@ -476,7 +532,8 @@ for (const def of toolDefs) {
   }
 }
 
-console.log(`[Init] MCP tools registered: ${toolDefs.filter(t => !t.name.startsWith('pa-auth-')).length}`);
+const mcpToolCount = toolDefs.filter(t => !t.name.startsWith('pa-auth-')).length;
+console.log(`[Init] MCP tools registered: ${mcpToolCount}`);
 
 // Register auth tools on McpServer via dedicated handler (uses TOOL_DESCRIPTIONS)
 registerAuthTools(mcpServer, userAuthManager);
@@ -621,6 +678,6 @@ app.listen(PORT, () => {
   console.log(`[Init] API:    BAP admin + Flow admin + PowerApps admin (3 scopes)`);
   console.log(`[Init] Write:  Delegated user token via Device Code Flow`);
   console.log(`[Init] Auth:   ${userAuthManager.isConfigured() ? 'Dual-token mode (service principal + per-user delegated)' : 'Service-principal only (UserAuth not configured)'}`);
-  console.log(`[Init] Tools:  ${toolDefs.length} (15 MCP + 3 auth, enhanced descriptions)`);
+  console.log(`[Init] Tools:  ${toolDefs.length} (${mcpToolCount} MCP + 3 auth, enhanced descriptions)`);
   console.log('');
 });

--- a/src/tools/tool-descriptions.ts
+++ b/src/tools/tool-descriptions.ts
@@ -1,6 +1,6 @@
 /**
  * Tool Descriptions for Power Automate MCP
- * v3.0.3 - Includes flow creation procedure guidance
+ * v3.1.0 - Added pa-get-connection and pa-delete-connection
  *
  * These descriptions are embedded in the MCP tool schema and visible
  * to AI agents when they discover available tools. The procedure
@@ -8,7 +8,7 @@
  * on misread API responses.
  */
 
-export const TOOL_DESCRIPTIONS = {
+export const TOOL_DESCRIPTIONS: Record<string, string> = {
   // =========================================================================
   // AUTH TOOLS
   // =========================================================================
@@ -181,7 +181,21 @@ export const TOOL_DESCRIPTIONS = {
     'List API connections in the environment.',
     'Shows connection status, type, and authorization state.',
   ].join('\n'),
-} as const;
+
+  'pa-get-connection': [
+    'Get details for a specific API connection.',
+    'Returns connection status, connector type, authorization state, and creator info.',
+    'Requires the connectionId (name field) from pa-list-connections.',
+  ].join('\n'),
+
+  'pa-delete-connection': [
+    'Delete an API connection from the environment permanently.',
+    '',
+    'WARNING: Deleting a connection may break flows that depend on it.',
+    'Check which flows reference this connection before deleting.',
+    'This action cannot be undone.',
+  ].join('\n'),
+};
 
 /**
  * Flow Creation Procedure Summary (for embedding in system prompts)


### PR DESCRIPTION
## Description

`pa-create-connection` fails when attempting to create a connection using the user's delegated token on the PowerApps connections endpoint.

## Progression

| Round | Error | Meaning |
|-------|-------|---------|
| v3.3.0 (deploy `930cda56`) | 403 Forbidden | Token acquired but wrong scope — Flow token hitting PowerApps API |
| v3.3.0 (deploy `7e1aef7b`) | `Could not acquire PowerApps delegated token` | Multi-scope refresh token exchange targeting correct scope (`service.powerapps.com`) but Azure AD rejecting the exchange |

## Root Cause (Confirmed)

The Azure AD app registration (`e5522464...`) does **not** have delegated permissions for **PowerApps Service** (`service.powerapps.com`). The refresh token from Device Code Flow can only be exchanged for resource scopes the app has been granted.

The code fix (UserAuthManager v2.1.0 `getAccessTokenForScope()`) is correct — it attempts the right exchange. Azure AD is rejecting it because the app lacks the permission.

## Fix Required (Azure Portal — NOT code)

1. Go to [Azure AD → App registrations](https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade)
2. Find the **power-automate-mcp** app (client ID `e5522464...`)
3. Click **API Permissions** → **Add a permission**
4. Select **PowerApps Service** (`service.powerapps.com`)
5. Choose **Delegated permissions** → check **User**
6. Click **Add permissions**
7. Click **Grant admin consent for Bolthouse Fresh** (requires Global Admin or Privileged Role Admin)
8. **Re-authenticate** — run `pa-auth-start` again so the next Device Code Flow produces a refresh token eligible for the `service.powerapps.com` scope exchange

## Verification

After granting consent, re-run Test 4. Expected logs:
```
[UserAuth] Acquiring powerapps token for Timothy.Escamilla@... via refresh token exchange...
[UserAuth] ✅ powerapps token acquired for Timothy.Escamilla@... (TTL: 3599s)
[CreateConnection] POST ...api.powerapps.com... (token: powerapps-delegated)
```

## Code Status

- `UserAuthManager` v2.1.0 — multi-scope refresh token exchange is **implemented and deployed** (`7e1aef7b`)
- `index.ts` — `pa-create-connection` calls `getAccessTokenForScope(userId, 'https://service.powerapps.com/.default')` ✅
- No further code changes needed — this is an Azure AD consent configuration issue