### PR TITLE
feat(v3.2.0): Dataverse Solutions API integration

### DIFF
--- a/src/clients/solution-client.ts
+++ b/src/clients/solution-client.ts
@@ -1,0 +1,348 @@
+/**
+ * SolutionClient — Dataverse Solutions API client
+ *
+ * Provides access to Dataverse Web API v9.2 for solution lifecycle management.
+ * Uses service principal token (AzureTokenManager) with Dataverse scope.
+ *
+ * Operations:
+ *   - List solutions (unmanaged or all)
+ *   - Get solution details (by GUID or unique name)
+ *   - List solution components
+ *   - Export solution as base64 ZIP
+ *   - Add component to solution (e.g., add a Cloud Flow)
+ *
+ * Prerequisites:
+ *   - DATAVERSE_URL env var (e.g., org99066845.crm.dynamics.com)
+ *   - Service principal registered as Application User in Dataverse
+ *   - System Customizer role assigned to the Application User
+ *
+ * @version 3.2.0
+ */
+
+import axios from 'axios';
+import { AzureTokenManager } from '../auth/azure-token-manager.js';
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const DATAVERSE_API_VERSION = 'v9.2';
+
+/** Dataverse component type codes → human-readable names */
+export const COMPONENT_TYPES: Record<number, string> = {
+  1: 'Entity',
+  2: 'Attribute',
+  3: 'Relationship',
+  9: 'OptionSet',
+  10: 'EntityRelationship',
+  26: 'View',
+  29: 'Workflow',
+  60: 'SystemForm',
+  61: 'WebResource',
+  62: 'SiteMap',
+  63: 'ConnectionRole',
+  65: 'HierarchyRule',
+  66: 'CustomControl',
+  80: 'ModelDrivenApp',
+  300: 'CanvasApp',
+  371: 'Connector',
+  372: 'EnvironmentVariableDefinition',
+  373: 'EnvironmentVariableValue',
+  380: 'AIModel',
+  381: 'AITemplate',
+  400: 'DesktopFlow',
+};
+
+// =============================================================================
+// Exported Types
+// =============================================================================
+
+export interface SolutionSummary {
+  solutionId: string;
+  uniqueName: string;
+  friendlyName: string;
+  version: string;
+  isManaged: boolean;
+  installedOn: string | null;
+  modifiedOn: string | null;
+  description: string | null;
+  publisherId: string | null;
+}
+
+export interface SolutionComponent {
+  componentId: string;
+  objectId: string;
+  componentType: number;
+  componentTypeName: string;
+  isMetadata: boolean;
+}
+
+export interface ExportResult {
+  fileName: string;
+  base64Content: string;
+  sizeBytes: number;
+}
+
+// =============================================================================
+// SolutionClient
+// =============================================================================
+
+export class SolutionClient {
+  private tokenManager: AzureTokenManager;
+  private dataverseUrl: string;
+  private baseUrl: string;
+  private scope: string;
+
+  constructor(tokenManager: AzureTokenManager) {
+    this.tokenManager = tokenManager;
+
+    const envUrl = (process.env.DATAVERSE_URL || '').trim();
+    if (!envUrl) {
+      console.warn('[SolutionClient] DATAVERSE_URL not set — Dataverse operations disabled');
+      this.dataverseUrl = '';
+      this.baseUrl = '';
+      this.scope = '';
+    } else {
+      // Normalize: ensure https:// prefix and no trailing slash
+      this.dataverseUrl = envUrl.startsWith('https://') ? envUrl : `https://${envUrl}`;
+      this.dataverseUrl = this.dataverseUrl.replace(/\/+$/, '');
+      this.baseUrl = `${this.dataverseUrl}/api/data/${DATAVERSE_API_VERSION}`;
+      this.scope = `${this.dataverseUrl}/.default`;
+      console.log(`[SolutionClient] Dataverse configured: ${this.dataverseUrl}`);
+      console.log(`[SolutionClient]   Scope: ${this.scope}`);
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Configuration
+  // -----------------------------------------------------------------------
+
+  /** Returns true if DATAVERSE_URL is configured. */
+  isConfigured(): boolean {
+    return !!this.dataverseUrl;
+  }
+
+  /** Returns the Dataverse token scope for pre-warming. */
+  getScope(): string {
+    return this.scope;
+  }
+
+  // -----------------------------------------------------------------------
+  // Internal Request Helper
+  // -----------------------------------------------------------------------
+
+  private async dataverseRequest(
+    path: string,
+    method: string = 'GET',
+    body?: any
+  ): Promise<any> {
+    if (!this.isConfigured()) {
+      throw new Error(
+        'Dataverse not configured. Set DATAVERSE_URL environment variable ' +
+        '(e.g., org99066845.crm.dynamics.com).'
+      );
+    }
+
+    const token = await this.tokenManager.getToken(this.scope);
+    const url = `${this.baseUrl}${path}`;
+
+    console.log(`[SolutionClient] ${method} ${path}`);
+
+    const response = await axios({
+      method,
+      url,
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+        'OData-MaxVersion': '4.0',
+        'OData-Version': '4.0',
+      },
+      data: body,
+      validateStatus: (s) => s < 500,
+    });
+
+    if (response.status >= 400) {
+      const errMsg =
+        response.data?.error?.message ||
+        response.data?.Message ||
+        `HTTP ${response.status}`;
+      throw new Error(`Dataverse API error (${response.status}): ${errMsg}`);
+    }
+
+    return response.data;
+  }
+
+  // -----------------------------------------------------------------------
+  // Solution Operations
+  // -----------------------------------------------------------------------
+
+  /**
+   * Lists all solutions in the Dataverse environment.
+   * By default shows only unmanaged, visible solutions.
+   */
+  async listSolutions(includeManaged: boolean = false): Promise<SolutionSummary[]> {
+    let filter = 'isvisible eq true';
+    if (!includeManaged) {
+      filter += ' and ismanaged eq false';
+    }
+
+    const path =
+      `/solutions?$select=solutionid,uniquename,friendlyname,version,ismanaged,` +
+      `installedon,modifiedon,description,_publisherid_value` +
+      `&$filter=${encodeURIComponent(filter)}` +
+      `&$orderby=friendlyname asc`;
+
+    const data = await this.dataverseRequest(path);
+    const solutions = data.value || [];
+
+    console.log(`[SolutionClient] Found ${solutions.length} solutions`);
+
+    return solutions.map((s: any) => ({
+      solutionId: s.solutionid,
+      uniqueName: s.uniquename,
+      friendlyName: s.friendlyname,
+      version: s.version,
+      isManaged: s.ismanaged,
+      installedOn: s.installedon || null,
+      modifiedOn: s.modifiedon || null,
+      description: s.description || null,
+      publisherId: s._publisherid_value || null,
+    }));
+  }
+
+  /**
+   * Gets details for a specific solution.
+   * Accepts either a GUID (solutionid) or a unique name.
+   */
+  async getSolution(solutionIdOrName: string): Promise<SolutionSummary> {
+    const isGuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+      solutionIdOrName
+    );
+
+    let path: string;
+    if (isGuid) {
+      path =
+        `/solutions(${solutionIdOrName})?$select=solutionid,uniquename,friendlyname,` +
+        `version,description,ismanaged,installedon,modifiedon,_publisherid_value`;
+    } else {
+      path =
+        `/solutions?$select=solutionid,uniquename,friendlyname,version,description,` +
+        `ismanaged,installedon,modifiedon,_publisherid_value` +
+        `&$filter=uniquename eq '${solutionIdOrName}'`;
+    }
+
+    const data = await this.dataverseRequest(path);
+
+    // If queried by unique name, extract from value array
+    const s = isGuid ? data : data.value?.[0] || null;
+    if (!s) {
+      throw new Error(`Solution not found: ${solutionIdOrName}`);
+    }
+
+    return {
+      solutionId: s.solutionid,
+      uniqueName: s.uniquename,
+      friendlyName: s.friendlyname,
+      version: s.version,
+      isManaged: s.ismanaged,
+      installedOn: s.installedon || null,
+      modifiedOn: s.modifiedon || null,
+      description: s.description || null,
+      publisherId: s._publisherid_value || null,
+    };
+  }
+
+  /**
+   * Lists components within a solution.
+   * Returns component type, object ID, and human-readable type name.
+   */
+  async listSolutionComponents(solutionId: string): Promise<SolutionComponent[]> {
+    const path =
+      `/solutioncomponents?$filter=_solutionid_value eq '${solutionId}'` +
+      `&$select=solutioncomponentid,componenttype,objectid,ismetadata` +
+      `&$orderby=componenttype asc`;
+
+    const data = await this.dataverseRequest(path);
+    const components = data.value || [];
+
+    console.log(`[SolutionClient] Solution ${solutionId}: ${components.length} components`);
+
+    return components.map((c: any) => ({
+      componentId: c.solutioncomponentid,
+      objectId: c.objectid,
+      componentType: c.componenttype,
+      componentTypeName: COMPONENT_TYPES[c.componenttype] || `Unknown(${c.componenttype})`,
+      isMetadata: c.ismetadata || false,
+    }));
+  }
+
+  /**
+   * Exports a solution as a base64-encoded ZIP file.
+   * Uses the Dataverse ExportSolution action.
+   */
+  async exportSolution(
+    solutionUniqueName: string,
+    managed: boolean = false
+  ): Promise<ExportResult> {
+    console.log(`[SolutionClient] Exporting solution: ${solutionUniqueName} (managed: ${managed})`);
+
+    const body = {
+      SolutionName: solutionUniqueName,
+      Managed: managed,
+    };
+
+    const data = await this.dataverseRequest('/ExportSolution', 'POST', body);
+
+    const base64 = data.ExportSolutionFile || '';
+    const sizeBytes = Math.round((base64.length * 3) / 4);
+    const suffix = managed ? '_managed' : '';
+
+    console.log(`[SolutionClient] Exported ${solutionUniqueName}: ${Math.round(sizeBytes / 1024)}KB`);
+
+    return {
+      fileName: `${solutionUniqueName}${suffix}.zip`,
+      base64Content: base64,
+      sizeBytes,
+    };
+  }
+
+  /**
+   * Adds a component (e.g., a Cloud Flow) to a solution.
+   * Uses the Dataverse AddSolutionComponent action.
+   *
+   * Common component types:
+   *   29 = Workflow / Cloud Flow
+   *   1  = Entity / Table
+   *   300 = Canvas App
+   *   372 = Environment Variable Definition
+   */
+  async addSolutionComponent(
+    solutionUniqueName: string,
+    componentId: string,
+    componentType: number = 29,
+    addRequiredComponents: boolean = false
+  ): Promise<{ success: boolean; message: string }> {
+    const typeName = COMPONENT_TYPES[componentType] || `Type(${componentType})`;
+
+    console.log(
+      `[SolutionClient] Adding ${typeName} ${componentId} to solution ${solutionUniqueName}`
+    );
+
+    const body = {
+      ComponentId: componentId,
+      ComponentType: componentType,
+      SolutionUniqueName: solutionUniqueName,
+      AddRequiredComponents: addRequiredComponents,
+    };
+
+    await this.dataverseRequest('/AddSolutionComponent', 'POST', body);
+
+    console.log(`[SolutionClient] ✅ ${typeName} added to ${solutionUniqueName}`);
+
+    return {
+      success: true,
+      message: `${typeName} ${componentId} added to solution ${solutionUniqueName}`,
+    };
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import { z } from 'zod';
 import { AzureTokenManager } from './auth/azure-token-manager.js';
 import { PowerPlatformClient } from './api/power-platform-client.js';
+import { SolutionClient } from './clients/solution-client.js';
 import { resolveEnvironmentId } from './config/environment-resolver.js';
 import { ToolResult, ToolDefinition } from './types.js';
 import { UserAuthManager } from './auth/user-auth-manager.js';
@@ -15,7 +16,7 @@ import { registerAuthTools } from './tools/auth-tool-handlers.js';
 // Configuration
 // =============================================================================
 const PORT = parseInt(process.env.PORT || '8080', 10);
-const VERSION = '3.1.0';
+const VERSION = '3.2.0';
 
 // =============================================================================
 // Core Services
@@ -23,8 +24,9 @@ const VERSION = '3.1.0';
 const tokenManager = new AzureTokenManager();
 const userAuthManager = new UserAuthManager();
 const client = new PowerPlatformClient(tokenManager, userAuthManager);
+const solutionClient = new SolutionClient(tokenManager);
 
-// Pre-warm tokens (BAP + Flow + PowerApps scopes)
+// Pre-warm tokens (BAP + Flow + PowerApps + Dataverse scopes)
 (async () => {
   try {
     await tokenManager.getToken('https://api.bap.microsoft.com/.default');
@@ -38,6 +40,13 @@ const client = new PowerPlatformClient(tokenManager, userAuthManager);
     await tokenManager.getToken('https://service.powerapps.com/.default');
     console.log('[Init] PowerApps token acquired (service.powerapps.com)');
   } catch (e: any) { console.warn('[Init] PowerApps token pre-warm failed:', e.message); }
+  // Dataverse scope (if configured)
+  if (solutionClient.isConfigured()) {
+    try {
+      await tokenManager.getToken(solutionClient.getScope());
+      console.log(`[Init] Dataverse token acquired (${process.env.DATAVERSE_URL})`);
+    } catch (e: any) { console.warn('[Init] Dataverse token pre-warm failed:', e.message); }
+  }
 })();
 
 // =============================================================================
@@ -53,9 +62,9 @@ function fail(msg: string): ToolResult {
 // =============================================================================
 // Tool Definitions (shared between SSE + REST transports)
 //
+// v3.2.0: Added 5 Dataverse Solutions tools.
 // v3.1.0: Added pa-get-connection and pa-delete-connection tools.
-// v3.0.3: All descriptions sourced from TOOL_DESCRIPTIONS which include
-// mandatory flow creation procedure guidance for AI agents.
+// v3.0.3: All descriptions sourced from TOOL_DESCRIPTIONS.
 // =============================================================================
 const toolDefs: ToolDefinition[] = [
   // ---- List Environments ----
@@ -114,7 +123,6 @@ const toolDefs: ToolDefinition[] = [
       try {
         const envId = resolveEnvironmentId(p.environmentId);
         const result = await client.getFlowDetails(envId, p.flowId);
-        // Strip _raw to keep response manageable for agents
         if (result && result._raw) {
           const { _raw, ...clean } = result;
           return ok(clean);
@@ -403,8 +411,127 @@ const toolDefs: ToolDefinition[] = [
     },
   },
   // =========================================================================
+  // DATAVERSE SOLUTIONS TOOLS (v3.2.0)
+  // =========================================================================
+  // ---- List Solutions ----
+  {
+    name: 'pa-list-solutions',
+    description: TOOL_DESCRIPTIONS['pa-list-solutions'],
+    inputSchema: {
+      type: 'object',
+      properties: {
+        includeManaged: { type: 'boolean', description: 'Include managed solutions (default: false, shows unmanaged only).' },
+      },
+    },
+    handler: async (p: any) => {
+      try {
+        const solutions = await solutionClient.listSolutions(p.includeManaged === true);
+        return ok({ count: solutions.length, solutions });
+      } catch (e: any) { return fail(e.message); }
+    },
+  },
+  // ---- Get Solution Details ----
+  {
+    name: 'pa-get-solution',
+    description: TOOL_DESCRIPTIONS['pa-get-solution'],
+    inputSchema: {
+      type: 'object',
+      properties: {
+        solutionId: { type: 'string', description: 'Solution GUID or unique name.' },
+      },
+      required: ['solutionId'],
+    },
+    handler: async (p: any) => {
+      try {
+        const solution = await solutionClient.getSolution(p.solutionId);
+        return ok(solution);
+      } catch (e: any) { return fail(e.message); }
+    },
+  },
+  // ---- List Solution Components ----
+  {
+    name: 'pa-list-solution-components',
+    description: TOOL_DESCRIPTIONS['pa-list-solution-components'],
+    inputSchema: {
+      type: 'object',
+      properties: {
+        solutionId: { type: 'string', description: 'Solution GUID (from pa-list-solutions or pa-get-solution).' },
+      },
+      required: ['solutionId'],
+    },
+    handler: async (p: any) => {
+      try {
+        const components = await solutionClient.listSolutionComponents(p.solutionId);
+        // Group by type for readability
+        const byType: Record<string, number> = {};
+        for (const c of components) {
+          byType[c.componentTypeName] = (byType[c.componentTypeName] || 0) + 1;
+        }
+        return ok({ count: components.length, componentsByType: byType, components });
+      } catch (e: any) { return fail(e.message); }
+    },
+  },
+  // ---- Export Solution ----
+  {
+    name: 'pa-export-solution',
+    description: TOOL_DESCRIPTIONS['pa-export-solution'],
+    inputSchema: {
+      type: 'object',
+      properties: {
+        solutionUniqueName: { type: 'string', description: 'Solution unique name (from pa-list-solutions).' },
+        managed: { type: 'boolean', description: 'Export as managed solution (default: false).' },
+      },
+      required: ['solutionUniqueName'],
+    },
+    handler: async (p: any) => {
+      try {
+        const result = await solutionClient.exportSolution(
+          p.solutionUniqueName,
+          p.managed === true
+        );
+        return ok({
+          status: 'exported',
+          fileName: result.fileName,
+          sizeBytes: result.sizeBytes,
+          sizeHuman: result.sizeBytes < 1024
+            ? `${result.sizeBytes} bytes`
+            : result.sizeBytes < 1048576
+              ? `${Math.round(result.sizeBytes / 1024)}KB`
+              : `${(result.sizeBytes / 1048576).toFixed(1)}MB`,
+          managed: p.managed === true,
+          base64Content: result.base64Content,
+        });
+      } catch (e: any) { return fail(e.message); }
+    },
+  },
+  // ---- Add Solution Component ----
+  {
+    name: 'pa-add-solution-component',
+    description: TOOL_DESCRIPTIONS['pa-add-solution-component'],
+    inputSchema: {
+      type: 'object',
+      properties: {
+        solutionUniqueName: { type: 'string', description: 'Solution unique name to add the component to.' },
+        componentId: { type: 'string', description: 'GUID of the component (e.g., flow ID).' },
+        componentType: { type: 'number', description: 'Component type code (default: 29 = Cloud Flow).' },
+        addRequiredComponents: { type: 'boolean', description: 'Auto-include dependencies (default: false).' },
+      },
+      required: ['solutionUniqueName', 'componentId'],
+    },
+    handler: async (p: any) => {
+      try {
+        const result = await solutionClient.addSolutionComponent(
+          p.solutionUniqueName,
+          p.componentId,
+          p.componentType != null ? Number(p.componentType) : 29,
+          p.addRequiredComponents === true
+        );
+        return ok(result);
+      } catch (e: any) { return fail(e.message); }
+    },
+  },
+  // =========================================================================
   // AUTH TOOLS (Device Code Flow)
-  // Methods: startAuth(), pollAuth(), getAuthStatus()
   // =========================================================================
   // ---- Auth: Start Device Code Flow ----
   {
@@ -513,6 +640,8 @@ function toZodProps(inputSchema: any): Record<string, any> {
     let s;
     if (val.type === 'number') {
       s = z.number().describe(val.description || key);
+    } else if (val.type === 'boolean') {
+      s = z.boolean().describe(val.description || key);
     } else if (val.type === 'object' || val.type === 'array') {
       s = z.any().describe(val.description || key);
     } else {
@@ -524,7 +653,6 @@ function toZodProps(inputSchema: any): Record<string, any> {
 }
 
 // Register all tools on McpServer for SSE transport
-// Auth tools included in toolDefs so both transports get TOOL_DESCRIPTIONS
 for (const def of toolDefs) {
   if (!def.name.startsWith('pa-auth-')) {
     const zodProps = toZodProps(def.inputSchema);
@@ -553,6 +681,7 @@ app.get('/health', (_req: Request, res: Response) => {
     tools: toolDefs.length,
     transport: ['sse', 'rest'],
     auth: userAuthManager.isConfigured() ? 'dual-token' : 'service-principal-only',
+    dataverse: solutionClient.isConfigured() ? 'configured' : 'not-configured',
   });
 });
 
@@ -661,6 +790,7 @@ app.post('/tools', jsonParser, handleJsonRpc);
 console.log('[Init] Environment variable check:');
 console.log(`[Init]   POWER_PLATFORM_ENVIRONMENT_ID = ${process.env.POWER_PLATFORM_ENVIRONMENT_ID ? '"' + process.env.POWER_PLATFORM_ENVIRONMENT_ID + '"' : '(not set)'}`);
 console.log(`[Init]   AZURE_TENANT_ID = ${process.env.AZURE_TENANT_ID ? '(set)' : '(not set)'}`);
+console.log(`[Init]   DATAVERSE_URL = ${process.env.DATAVERSE_URL ? '"' + process.env.DATAVERSE_URL + '"' : '(not set)'}`);
 
 try {
   const defaultEnv = resolveEnvironmentId();
@@ -672,12 +802,13 @@ try {
 app.listen(PORT, () => {
   console.log('');
   console.log(`[Init] Power Automate MCP v${VERSION} running on port ${PORT}`);
-  console.log(`[Init] SSE:    http://localhost:${PORT}/sse`);
-  console.log(`[Init] REST:   http://localhost:${PORT}/mcp (+ /, /api, /tools)`);
-  console.log(`[Init] Health: http://localhost:${PORT}/health`);
-  console.log(`[Init] API:    BAP admin + Flow admin + PowerApps admin (3 scopes)`);
-  console.log(`[Init] Write:  Delegated user token via Device Code Flow`);
-  console.log(`[Init] Auth:   ${userAuthManager.isConfigured() ? 'Dual-token mode (service principal + per-user delegated)' : 'Service-principal only (UserAuth not configured)'}`);
-  console.log(`[Init] Tools:  ${toolDefs.length} (${mcpToolCount} MCP + 3 auth, enhanced descriptions)`);
+  console.log(`[Init] SSE:       http://localhost:${PORT}/sse`);
+  console.log(`[Init] REST:      http://localhost:${PORT}/mcp (+ /, /api, /tools)`);
+  console.log(`[Init] Health:    http://localhost:${PORT}/health`);
+  console.log(`[Init] API:       BAP admin + Flow admin + PowerApps admin (3 scopes)`);
+  console.log(`[Init] Dataverse: ${solutionClient.isConfigured() ? process.env.DATAVERSE_URL + ' (configured)' : 'Not configured (set DATAVERSE_URL)'}`);
+  console.log(`[Init] Write:     Delegated user token via Device Code Flow`);
+  console.log(`[Init] Auth:      ${userAuthManager.isConfigured() ? 'Dual-token mode (service principal + per-user delegated)' : 'Service-principal only (UserAuth not configured)'}`);
+  console.log(`[Init] Tools:     ${toolDefs.length} (${mcpToolCount} MCP + 3 auth)`);
   console.log('');
 });

--- a/src/tools/tool-descriptions.ts
+++ b/src/tools/tool-descriptions.ts
@@ -1,6 +1,6 @@
 /**
  * Tool Descriptions for Power Automate MCP
- * v3.1.0 - Added pa-get-connection and pa-delete-connection
+ * v3.2.0 - Added Dataverse Solutions tools
  *
  * These descriptions are embedded in the MCP tool schema and visible
  * to AI agents when they discover available tools. The procedure
@@ -195,13 +195,83 @@ export const TOOL_DESCRIPTIONS: Record<string, string> = {
     'Check which flows reference this connection before deleting.',
     'This action cannot be undone.',
   ].join('\n'),
+
+  // =========================================================================
+  // DATAVERSE SOLUTIONS TOOLS (v3.2.0)
+  // =========================================================================
+
+  'pa-list-solutions': [
+    'List Dataverse solutions in the environment.',
+    'Returns solution unique names, versions, managed/unmanaged status.',
+    '',
+    'By default shows only unmanaged solutions.',
+    'Set includeManaged=true to include Microsoft and third-party managed solutions.',
+    '',
+    'REQUIRES: DATAVERSE_URL environment variable configured.',
+  ].join('\n'),
+
+  'pa-get-solution': [
+    'Get details for a specific Dataverse solution.',
+    'Accepts either a solution GUID or unique name (case-sensitive).',
+    '',
+    'Returns version, description, publisher, managed status, and timestamps.',
+    '',
+    'REQUIRES: DATAVERSE_URL environment variable configured.',
+  ].join('\n'),
+
+  'pa-list-solution-components': [
+    'List all components within a Dataverse solution.',
+    'Returns component types (Entity, Workflow, Canvas App, etc.) and object IDs.',
+    '',
+    'Common component types:',
+    '  29 = Cloud Flow (Workflow)',
+    '  1  = Entity (Table)',
+    '  300 = Canvas App',
+    '  372 = Environment Variable',
+    '',
+    'Use the solutionId (GUID) from pa-list-solutions or pa-get-solution.',
+    '',
+    'REQUIRES: DATAVERSE_URL environment variable configured.',
+  ].join('\n'),
+
+  'pa-export-solution': [
+    'Export a Dataverse solution as a ZIP file (base64 encoded).',
+    '',
+    'Returns the solution file as base64 plus metadata (fileName, sizeBytes).',
+    'Set managed=true to export as a managed solution.',
+    '',
+    'Use solutionUniqueName (not friendly name) from pa-list-solutions.',
+    '',
+    'NOTE: Large solutions may produce very large responses.',
+    '',
+    'REQUIRES: DATAVERSE_URL environment variable configured.',
+  ].join('\n'),
+
+  'pa-add-solution-component': [
+    'Add a component (e.g., a Cloud Flow) to a Dataverse solution.',
+    '',
+    'This is the key ALM operation: it registers an existing component',
+    '(flow, table, app, etc.) into a solution for packaging and deployment.',
+    '',
+    'Parameters:',
+    '  solutionUniqueName — Solution to add the component to',
+    '  componentId — GUID of the component (e.g., flow ID from pa-list-flows)',
+    '  componentType — Numeric type code (default: 29 = Cloud Flow)',
+    '',
+    'Common component types:',
+    '  29  = Cloud Flow (Workflow)',
+    '  1   = Entity (Table)',
+    '  300 = Canvas App',
+    '  372 = Environment Variable Definition',
+    '',
+    'Set addRequiredComponents=true to auto-include dependencies.',
+    '',
+    'REQUIRES: DATAVERSE_URL environment variable configured.',
+  ].join('\n'),
 };
 
 /**
  * Flow Creation Procedure Summary (for embedding in system prompts)
- *
- * This is a compact version of the full procedure from
- * docs/skills/flow-creation-procedure.md
  */
 export const FLOW_CREATION_PROCEDURE = [
   'FLOW CREATION SEQUENCE (mandatory):',


### PR DESCRIPTION
# v3.2.0 — Dataverse Solutions API Integration

## Summary
Adds full Dataverse solution lifecycle management to the Power Automate MCP. Enables agents to list, inspect, export, and compose solutions — the foundation of Power Platform ALM.

## Prerequisites (before merge)
**Add this Railway environment variable:**
```
DATAVERSE_URL=org99066845.crm.dynamics.com
```
Without this, Dataverse tools will return a clear error message. Existing tools are unaffected.

## New Files

| File | Description |
|---|---|
| `src/clients/solution-client.ts` | Dataverse Web API v9.2 client — list, get, export solutions, list/add components |

## Modified Files

| File | Change | Impact |
|---|---|---|
| `src/tools/tool-descriptions.ts` | +5 Dataverse tool descriptions | Agent guidance for solution tools |
| `src/index.ts` | +5 tool handlers, SolutionClient init, Dataverse token pre-warm, `boolean` zod support, health endpoint `dataverse` field, version → 3.2.0 | Core wiring |

## New Tools (5)

| Tool | Method | Purpose |
|---|---|---|
| `pa-list-solutions` | GET | List Dataverse solutions (unmanaged by default) |
| `pa-get-solution` | GET | Get solution details by GUID or unique name |
| `pa-list-solution-components` | GET | List components in a solution (flows, tables, apps) |
| `pa-export-solution` | POST | Export solution as base64 ZIP |
| `pa-add-solution-component` | POST | Add a component (e.g., Cloud Flow) to a solution |

## Tool Count
- **Before:** 18 tools (15 MCP + 3 auth)
- **After:** 23 tools (20 MCP + 3 auth)

## Architecture

```
AzureTokenManager
  └─ getToken('https://org99066845.crm.dynamics.com/.default')
       └─ SolutionClient (Dataverse Web API v9.2)
            ├─ listSolutions()
            ├─ getSolution()
            ├─ listSolutionComponents()
            ├─ exportSolution()
            └─ addSolutionComponent()
```

## Key Design Decisions
- **Service principal auth only** — Dataverse operations use client credentials (System Administrator role confirmed)
- **Graceful degradation** — if `DATAVERSE_URL` not set, solution tools return clear error, all other tools work fine
- **Component type mapping** — human-readable names for 20+ component types (Entity, Workflow, CanvasApp, etc.)
- **GUID or name lookup** — `pa-get-solution` accepts either format
- **groupBy in components** — response includes `componentsByType` summary for agent readability

## Verification After Deploy
1. Check `/health` → `version: '3.2.0'`, `tools: 23`, `dataverse: 'configured'`
2. Check startup logs → `[Init] Dataverse token acquired (org99066845.crm.dynamics.com)`
3. Call `pa-list-solutions` → should return unmanaged solutions
4. Call `pa-get-solution` with a unique name → should return details"