### PR TITLE
feat: Harden Azure AD authentication durability

### DIFF
--- a/src/auth/azure-token-manager.ts
+++ b/src/auth/azure-token-manager.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { TokenInfo } from '../types.js';
 
-const REFRESH_BUFFER_MS = 5 * 60 * 1000;
+const REFRESH_BUFFER_MS = 10 * 60 * 1000;
 
 export class AzureTokenManager {
   private tokens: Map<string, TokenInfo> = new Map();

--- a/src/auth/token-store.ts
+++ b/src/auth/token-store.ts
@@ -9,7 +9,7 @@ export class TokenStore {
   get(scope: string): string | null {
     const stored = this.tokens.get(scope);
     if (!stored) return null;
-    if (Date.now() >= stored.expiresAt - 5 * 60 * 1000) return null;
+    if (Date.now() >= stored.expiresAt - 10 * 60 * 1000) return null;
     return stored.accessToken;
   }
 

--- a/src/auth/user-auth-manager.ts
+++ b/src/auth/user-auth-manager.ts
@@ -59,6 +59,7 @@ interface UserToken {
   expiresAt: number;
   userId: string;
   acquiredAt: number;
+  refreshCount: number;
 }
 
 interface PendingDeviceAuth {
@@ -74,7 +75,7 @@ interface PendingDeviceAuth {
 // Constants
 // =========================================================================
 
-const REFRESH_BUFFER_MS = 5 * 60 * 1000;  // Refresh when < 5 min remaining
+const REFRESH_BUFFER_MS = 10 * 60 * 1000;  // Refresh when < 10 min remaining
 const DEFAULT_SCOPE = 'https://service.flow.microsoft.com/.default offline_access';
 
 // =========================================================================
@@ -249,6 +250,7 @@ export class UserAuthManager {
         expiresAt: Date.now() + (data.expires_in * 1000),
         userId,
         acquiredAt: Date.now(),
+        refreshCount: 0,
       });
 
       this.pendingAuths.delete(userId);
@@ -394,7 +396,8 @@ export class UserAuthManager {
     // Auto-refresh if < 5 min remaining
     if (token.expiresAt - Date.now() < REFRESH_BUFFER_MS) {
       if (token.refreshToken) {
-        console.log(`[UserAuth] Token for ${targetUser} expiring soon, refreshing...`);
+        const currentCount = token.refreshCount || 0;
+        console.log(`[UserAuth] Token for ${targetUser} expiring soon (refreshCount: ${currentCount}), refreshing...`);
         const refreshed = await this.refreshTokenForUser(targetUser, token.refreshToken);
         if (refreshed) {
           return this.tokens.get(targetUser)!.accessToken;
@@ -488,16 +491,16 @@ export class UserAuthManager {
       });
 
       const data = response.data;
-
+      const prevCount = this.tokens.get(userId)?.refreshCount || 0;
       this.tokens.set(userId, {
         accessToken: data.access_token,
         refreshToken: data.refresh_token || refreshToken,
         expiresAt: Date.now() + (data.expires_in * 1000),
         userId,
         acquiredAt: Date.now(),
+        refreshCount: prevCount + 1,
       });
-
-      console.log(`[UserAuth] ✅ Token refreshed for ${userId} (TTL: ${data.expires_in}s)`);
+      console.log(`[UserAuth] Token refreshed for ${userId} (TTL: ${data.expires_in}s, refreshCount: ${prevCount + 1})`);
       return true;
     } catch (error: any) {
       const errMsg = error.response?.data?.error_description || error.response?.data?.error || error.message;
@@ -550,6 +553,7 @@ export class UserAuthManager {
         expiresAt: Date.now() + (data.expires_in * 1000),
         userId,
         acquiredAt: Date.now(),
+        refreshCount: 0,
       });
 
       // Sync refresh token back to primary if Azure AD rotated it


### PR DESCRIPTION
## Summary

Widens the Azure AD token refresh safety margin from **5 minutes to 10 minutes** across all three auth modules, and adds `refreshCount` tracking to `UserAuthManager` for diagnostics.

## Problem

Long-running agentic workflows were failing because the 5-minute (300s) refresh buffer was too tight. Network latency and processing delays could cause the access token to expire before a silent refresh completed, forcing repeated re-authentication prompts.

## Changes

### `src/auth/user-auth-manager.ts`
- **Widened `REFRESH_BUFFER_MS`** from `5 * 60 * 1000` to `10 * 60 * 1000` (5 min → 10 min)
- **Added `refreshCount: number`** to the `UserToken` interface
- **Initialized `refreshCount: 0`** in `pollAuth()` and `acquireScopedToken()` token storage
- **Incremented `refreshCount`** on each successful silent refresh in `refreshTokenForUser()`
- **Enhanced logging** — refresh and expiry-warning logs now include `refreshCount` for diagnostics

### `src/auth/azure-token-manager.ts`
- **Widened `REFRESH_BUFFER_MS`** from `5 * 60 * 1000` to `10 * 60 * 1000`

### `src/auth/token-store.ts`
- **Widened expiry buffer** from `5 * 60 * 1000` to `10 * 60 * 1000` in the `get()` method

## Note

The `offline_access` scope was already present in `DEFAULT_SCOPE` (`'https://service.flow.microsoft.com/.default offline_access'`), so no scope change was needed. The root cause was the tight refresh margin, not a missing scope.

## Post-Deployment

After merging, users must perform a **one-time re-authentication** (via `pa-auth-start`) to acquire a fresh token under the hardened pipeline. After that, silent refresh should function reliably for up to 90 days of inactivity per Azure AD policy.