### PR TITLE
fix: Resolve 403 Forbidden in pa-create-connection by adding PowerApps scope

### DIFF
--- a/src/auth/user-auth-manager.ts
+++ b/src/auth/user-auth-manager.ts
@@ -76,7 +76,7 @@ interface PendingDeviceAuth {
 // =========================================================================
 
 const REFRESH_BUFFER_MS = 10 * 60 * 1000;  // Refresh when < 10 min remaining
-const DEFAULT_SCOPE = 'https://service.flow.microsoft.com/.default offline_access';
+const DEFAULT_SCOPE = 'https://service.flow.microsoft.com/.default https://service.powerapps.com/.default offline_access';
 
 // =========================================================================
 // UserAuthManager


### PR DESCRIPTION
## Problem
`pa-create-connection` returns **403 Forbidden** when using a delegated (Device Code Flow) token. (Issue #15)

## Root Cause
The `DEFAULT_SCOPE` in `user-auth-manager.ts` only requests consent for `service.flow.microsoft.com`, but `pa-create-connection` calls `getAccessTokenForScope('https://service.powerapps.com/.default')`. Since the user never consented to the PowerApps scope during authentication, Azure AD issues a token lacking PowerApps permissions, causing the 403.

## Fix
Added `https://service.powerapps.com/.default` to `DEFAULT_SCOPE`, so the Device Code Flow requests consent for **both** Flow and PowerApps resources simultaneously.

```diff
- const DEFAULT_SCOPE = 'https://service.flow.microsoft.com/.default offline_access';
+ const DEFAULT_SCOPE = 'https://service.flow.microsoft.com/.default https://service.powerapps.com/.default offline_access';
```

## Post-Deployment
After deploying this fix, users must run `pa-auth-start` **once** to re-authenticate and grant consent for the new PowerApps scope. After that, `pa-create-connection` will work correctly.

## No Regression
All existing tools (Flow read/write) continue to use the Flow scope as before. The `getAccessTokenForScope()` method already correctly acquires the right token for each API call.

Closes #15