### PR TITLE
hotfix: Revert DEFAULT_SCOPE to restore pa-auth-start (fixes AADSTS70011)

### DIFF
--- a/src/auth/user-auth-manager.ts
+++ b/src/auth/user-auth-manager.ts
@@ -76,7 +76,7 @@ interface PendingDeviceAuth {
 // =========================================================================
 
 const REFRESH_BUFFER_MS = 10 * 60 * 1000;  // Refresh when < 10 min remaining
-const DEFAULT_SCOPE = 'https://service.flow.microsoft.com/.default https://service.powerapps.com/.default offline_access';
+const DEFAULT_SCOPE = 'https://service.flow.microsoft.com/.default offline_access';
 
 // =========================================================================
 // UserAuthManager


### PR DESCRIPTION
## Problem

PR #17 added `https://service.powerapps.com/.default` to `DEFAULT_SCOPE` in `src/auth/user-auth-manager.ts`. This causes Azure AD's Device Code Flow to fail with:

> **AADSTS70011: static scope limit exceeded**

Azure AD Device Code Flow for user-delegated tokens **cannot request `.default` scopes for multiple resources in a single consent request**. The multi-scope `DEFAULT_SCOPE` broke `pa-auth-start` completely.

## Fix

Reverts `DEFAULT_SCOPE` to a **single-resource scope**:

```typescript
// Before (broken)
const DEFAULT_SCOPE = 'https://service.flow.microsoft.com/.default https://service.powerapps.com/.default offline_access';

// After (fixed)
const DEFAULT_SCOPE = 'https://service.flow.microsoft.com/.default offline_access';
```

## Why this is safe

The codebase already has a proper multi-resource token acquisition mechanism:

- `getAccessTokenForScope(userId, scope)` checks the `scopedTokens` cache
- `acquireScopedToken()` exchanges the **refresh token** for a PowerApps-scoped access token on demand
- `pa-create-connection` already calls `getAccessTokenForScope(..., 'https://service.powerapps.com/.default')`

So PowerApps connections will still work — they just get their token via refresh-token exchange after the initial Flow auth succeeds.

## Deployment

1. Merge this PR → Railway auto-deploys
2. Run `pa-auth-start` once to get a fresh token under the single-scope flow
3. `pa-create-connection` will work via `acquireScopedToken`